### PR TITLE
[Broken, do not merge] HIC-TRE custom UI changes

### DIFF
--- a/src/components/egress/EgressRequestList.js
+++ b/src/components/egress/EgressRequestList.js
@@ -77,17 +77,7 @@ function EgressRequestList() {
 
     // Toggles open/close for modal
     const toggleModal = (request) => {
-        console.log(`state in handler: ${showModalRef.current}`);
-
-        console.log(
-            'toggleModal:',
-            // 'toggleModal: request: ', request,
-            'showModal:',
-            showModal,
-        );
-
         setShowModalRef(!showModalRef.current);
-        // setShowModal(!showModal);
 
         if (request !== undefined) {
             setSelectedEgressRequest(request);
@@ -166,8 +156,6 @@ function EgressRequestList() {
 
     // Call on every state change
     useEffect(() => {
-        console.log('useEffect (no params)');
-
         getAllEgressRequests().then((data) =>
             // Set state using API data and imported headers
             setEgressRequestList({
@@ -181,15 +169,6 @@ function EgressRequestList() {
 
     // Effect to be invoked whenever an egress request is selected i.e. when modal is displayed
     useEffect(() => {
-        // console.log(
-        //     'useEffect: selectedEgressRequest: ',
-        //     selectedEgressRequest,
-        //     'userRole:',
-        //     userRole,
-        //     'selectedEgressRequest.download_count:',
-        //     selectedEgressRequest.download_count,
-        // );
-
         setIsEditable(
             (selectedEgressRequest.formattedStatus === 'PENDING' && userRole === 'reviewer_1') ||
                 (selectedEgressRequest.formattedStatus === 'IGAPPROVED' && userRole === 'reviewer_2'),
@@ -247,8 +226,6 @@ function EgressRequestList() {
 
     // Make API call to download API
     const handleDownload = async () => {
-        // console.log('selectedEgressRequest', selectedEgressRequest);
-
         setDownloading(true);
         const count = selectedEgressRequest.download_count == null ? 0 : selectedEgressRequest.download_count;
         const requestDetails = {
@@ -350,25 +327,17 @@ function EgressRequestList() {
 
     // Triggers update of request whenever a confirmation on the dialogue box is made
     useEffect(() => {
-        console.log('useEffect: confirmed:', confirmed);
-
         if (confirmed) {
             updateEgressRequest();
 
             //reload the request table.
-            //for some reason performing this immediately doesn't seem to work, so let's test with a timeout to see if that makes any difference...
-            setTimeout(function () {
-                console.log('CALLING getAllEgressRequests()');
-
-                getAllEgressRequests().then((data) =>
-                    // Set state using API data and imported headers
-                    setEgressRequestList({
-                        columns: columnHeaders,
-                        rows: data,
-                    }),
-                );
-                //not sure why this is required...
-            }, 10000);
+            getAllEgressRequests().then((data) =>
+                // Set state using API data and imported headers
+                setEgressRequestList({
+                    columns: columnHeaders,
+                    rows: data,
+                }),
+            );
         }
 
         setConfirmed(false);

--- a/src/components/egress/EgressRequestList.js
+++ b/src/components/egress/EgressRequestList.js
@@ -62,9 +62,9 @@ function EgressRequestList() {
     const [confirmationOpen, setConfirmationOpen] = useState(false);
     const [confirmed, setConfirmed] = useState(false);
 
-    const myStateRef = React.useRef(showModal);
-    const setMyState = (data) => {
-        myStateRef.current = data;
+    const showModalRef = React.useRef(showModal);
+    const setShowModalRef = (data) => {
+        showModalRef.current = data;
         setShowModal(data);
     };
 
@@ -76,7 +76,7 @@ function EgressRequestList() {
 
     // Toggles open/close for modal
     const toggleModal = (request) => {
-        console.log(`state in handler: ${myStateRef.current}`);
+        console.log(`state in handler: ${showModalRef.current}`);
 
         console.log(
             'toggleModal:',
@@ -85,7 +85,7 @@ function EgressRequestList() {
             showModal,
         );
 
-        setMyState(!myStateRef.current);
+        setShowModalRef(!showModalRef.current);
         // setShowModal(!showModal);
 
         if (request !== undefined) {
@@ -166,10 +166,6 @@ function EgressRequestList() {
     // Call on every state change
     useEffect(() => {
         console.log('useEffect (no params)');
-
-        // setInterval(function () {
-        //     console.log('myStateRef.current', myStateRef.current);
-        // }, 1000);
 
         getAllEgressRequests().then((data) =>
             // Set state using API data and imported headers

--- a/src/components/egress/EgressRequestList.js
+++ b/src/components/egress/EgressRequestList.js
@@ -318,6 +318,10 @@ function EgressRequestList() {
             try {
                 await API.graphql(graphqlOperation(updateRequest, { request: requestDetails }));
                 setNotificationMessage('Request saved successfully.');
+                if (selectedEgressRequest.is_single_approval_enabled) {
+                    if (decision === 'APPROVED') setIsDownloadable(true);
+                    setIsEditable(false);
+                }
             } catch (err) {
                 setNotificationMessage(err.errors[0].message);
             }
@@ -329,20 +333,6 @@ function EgressRequestList() {
     useEffect(() => {
         if (confirmed) {
             updateEgressRequest();
-
-            toggleModal();
-
-            // reload the request table.
-            // annoyingly this doesn't seem to work without a time delay
-            setTimeout(function () {
-                getAllEgressRequests().then((data) =>
-                    // Set state using API data and imported headers
-                    setEgressRequestList({
-                        columns: columnHeaders,
-                        rows: data,
-                    }),
-                );
-            }, 250);
         }
 
         setConfirmed(false);

--- a/src/components/egress/EgressRequestList.js
+++ b/src/components/egress/EgressRequestList.js
@@ -330,7 +330,7 @@ function EgressRequestList() {
         if (confirmed) {
             updateEgressRequest();
 
-            //reload the request table.
+            // reload the request table.
             getAllEgressRequests().then((data) =>
                 // Set state using API data and imported headers
                 setEgressRequestList({

--- a/src/components/egress/EgressRequestList.js
+++ b/src/components/egress/EgressRequestList.js
@@ -330,14 +330,19 @@ function EgressRequestList() {
         if (confirmed) {
             updateEgressRequest();
 
+            toggleModal();
+
             // reload the request table.
-            getAllEgressRequests().then((data) =>
-                // Set state using API data and imported headers
-                setEgressRequestList({
-                    columns: columnHeaders,
-                    rows: data,
-                }),
-            );
+            // annoyingly this doesn't seem to work without a time delay
+            setTimeout(function () {
+                getAllEgressRequests().then((data) =>
+                    // Set state using API data and imported headers
+                    setEgressRequestList({
+                        columns: columnHeaders,
+                        rows: data,
+                    }),
+                );
+            }, 250);
         }
 
         setConfirmed(false);


### PR DESCRIPTION
These are the last custom UI changes made to the HIC-TRE fork. They are specific to the single approver workflow, and remove the need to refresh the UI after approval to obtain the download button, as well as adding a button to copy the download URL so this can be passed directly to a researcher.

This can't be merged into the main branch yet as it breaks the dual-approval UI workflow- should be a fairly simple fix for someone who knows React.

Please push to this branch if you have a fix (or open a new PR with these commits if you don't have push access).

Todo:
- [ ] Ensure this works when dual-approvers are configured

https://jira.hic.dundee.ac.uk/browse/AWSCLOU-336

----

Declaration : _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
