### PR TITLE
Check for errors in main list page

### DIFF
--- a/src/components/NavBar/navbar.js
+++ b/src/components/NavBar/navbar.js
@@ -12,15 +12,29 @@ import Grid from '@mui/material/Grid';
 import { Auth } from 'aws-amplify';
 import { Button } from '@mui/material';
 import './navbar.css';
+import awsconfig from '../../aws-config';
 
 function NavBar() {
     const [user, setUser] = useState();
+    const [userGroup, setUserGroup] = useState('');
     function getUser() {
         return Auth.currentAuthenticatedUser().then((userData) => userData);
     }
 
     useEffect(() => {
-        getUser().then((userData) => setUser(userData));
+        getUser().then((userData) => {
+            setUser(userData);
+            let group;
+            const cognitoGroups = userData.signInUserSession.idToken.payload['cognito:groups'];
+            if (cognitoGroups.includes(awsconfig.egress_ig_role)) {
+                group = awsconfig.egress_ig_role;
+            } else if (cognitoGroups.includes(awsconfig.egress_rit_role)) {
+                group = awsconfig.egress_rit_role;
+            } else {
+                group = '';
+            }
+            setUserGroup(group);
+        });
     }, []);
 
     return (
@@ -38,7 +52,7 @@ function NavBar() {
                             {(user?.attributes?.name || user?.attributes?.email) && (
                                 <Typography variant="h7" color="inherit" style={{ flexGrow: 1 }}>
                                     {user?.attributes?.name ? user.attributes.name : user.attributes.email} logged in as{' '}
-                                    {user.signInUserSession.idToken.payload['cognito:groups'][0]}
+                                    {userGroup}
                                 </Typography>
                             )}
                         </Grid>


### PR DESCRIPTION
# Description

Previously error notifications were sent to a component that was part of the modal popup when a single egress request was selected. This means any errors on the listing page would never show, since the modal wasn't visible- the user would just see an empty list.

Since these errors are usually blockers I've made them into a non-closable [alert](https://mui.com/material-ui/react-alert/) instead:

![image](https://github.com/HicResearch/treehoose-egress-app-frontend/assets/1644105/27c8854a-5ece-46d6-a57e-72304de0c1ac)

In addition I've changed the navbar user/group display to only show the relevant group membership

----

Declaration : _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
