### PR TITLE
Add copy link button

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,11 @@
     "parserOptions": {
         "ecmaFeatures": { "jsx": true, "modules": true },
         "ecmaVersion": 2018,
-        "sourceType": "module"
+        "sourceType": "module",
+        "requireConfigFile": false,
+        "babelOptions": {
+            "presets": ["@babel/preset-react"]
+        }
     },
     "plugins": ["react", "prettier"],
     "rules": {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+name: Test
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint and security checks
+        run: npm run pipeline
+
+      - name: Build
+        run: npm run build
+
+      # There are no tests
+      # - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
             },
             "devDependencies": {
                 "@babel/eslint-parser": "7.22.5",
+                "@babel/preset-react": "7.22.5",
                 "eslint": "8.42.0",
                 "eslint-config-airbnb": "19.0.4",
                 "eslint-config-prettier": "8.8.0",
@@ -4454,11 +4455,11 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
-            "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+            "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
             "dependencies": {
-                "@babel/types": "^7.16.7"
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4603,11 +4604,11 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-            "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
+            "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
             "dependencies": {
-                "@babel/types": "^7.16.7"
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4643,9 +4644,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
-            "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+            "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -4711,18 +4712,26 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-            "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-            "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
+            "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -5211,11 +5220,11 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.17.12.tgz",
-            "integrity": "sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+            "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.17.12"
+                "@babel/helper-plugin-utils": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -5724,11 +5733,11 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-display-name": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz",
-            "integrity": "sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.22.5.tgz",
+            "integrity": "sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
+                "@babel/helper-plugin-utils": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -5738,15 +5747,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.12.tgz",
-            "integrity": "sha512-Lcaw8bxd1DKht3thfD4A12dqo1X16he1Lm8rIv8sTwjAYNInRS1qHa9aJoqvzpscItXvftKDCfaEQzwoVyXpEQ==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz",
+            "integrity": "sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-module-imports": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.17.12",
-                "@babel/plugin-syntax-jsx": "^7.17.12",
-                "@babel/types": "^7.17.12"
+                "@babel/helper-annotate-as-pure": "^7.22.5",
+                "@babel/helper-module-imports": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/plugin-syntax-jsx": "^7.22.5",
+                "@babel/types": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -5756,11 +5765,11 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx-development": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz",
-            "integrity": "sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
+            "integrity": "sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
             "dependencies": {
-                "@babel/plugin-transform-react-jsx": "^7.16.7"
+                "@babel/plugin-transform-react-jsx": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -5800,12 +5809,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.16.7.tgz",
-            "integrity": "sha512-hs71ToC97k3QWxswh2ElzMFABXHvGiJ01IB1TbYQDGeWRKWz/MPUTh5jGExdHvosYKpnJW5Pm3S4+TA3FyX+GA==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.22.5.tgz",
+            "integrity": "sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
+                "@babel/helper-annotate-as-pure": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -6097,16 +6106,16 @@
             }
         },
         "node_modules/@babel/preset-react": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.17.12.tgz",
-            "integrity": "sha512-h5U+rwreXtZaRBEQhW1hOJLMq8XNJBQ/9oymXiCXTuT/0uOwpbT0gUt+sXeOqoXBgNuUKI7TaObVwoEyWkpFgA==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.22.5.tgz",
+            "integrity": "sha512-M+Is3WikOpEJHgR385HbuCITPTaPRaNkibTEa9oiofmJvIsrceb4yp9RL9Kb+TE8LznmeyZqpP+Lopwcx59xPQ==",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.17.12",
-                "@babel/helper-validator-option": "^7.16.7",
-                "@babel/plugin-transform-react-display-name": "^7.16.7",
-                "@babel/plugin-transform-react-jsx": "^7.17.12",
-                "@babel/plugin-transform-react-jsx-development": "^7.16.7",
-                "@babel/plugin-transform-react-pure-annotations": "^7.16.7"
+                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-validator-option": "^7.22.5",
+                "@babel/plugin-transform-react-display-name": "^7.22.5",
+                "@babel/plugin-transform-react-jsx": "^7.22.5",
+                "@babel/plugin-transform-react-jsx-development": "^7.22.5",
+                "@babel/plugin-transform-react-pure-annotations": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -6195,11 +6204,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.17.12",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.12.tgz",
-            "integrity": "sha512-rH8i29wcZ6x9xjzI5ILHL/yZkbQnCERdHlogKuIb4PUr7do4iT8DPekrTbBLWTnRQm6U0GYABbTMSzijmEqlAg==",
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
+            "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.16.7",
+                "@babel/helper-string-parser": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.5",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     },
     "devDependencies": {
         "@babel/eslint-parser": "7.22.5",
+        "@babel/preset-react": "7.22.5",
         "eslint": "8.42.0",
         "eslint-config-airbnb": "19.0.4",
         "eslint-config-prettier": "8.8.0",

--- a/src/components/egress/EgressRequestList.js
+++ b/src/components/egress/EgressRequestList.js
@@ -25,6 +25,7 @@ import Snackbar from '@mui/material/Snackbar';
 import SnackbarContent from '@mui/material/SnackbarContent';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import FileDownloadIcon from '@mui/icons-material/FileDownloadRounded';
 import ThumbUpRoundedIcon from '@mui/icons-material/ThumbUpRounded';
 import ThumbDownRoundedIcon from '@mui/icons-material/ThumbDownRounded';
@@ -242,7 +243,7 @@ function EgressRequestList() {
     };
 
     // Make API call to download API
-    const handleDownload = async () => {
+    const handleDownloadOrCopy = async (copyToClipboard) => {
         setDownloading(true);
         const count = selectedEgressRequest.download_count == null ? 0 : selectedEgressRequest.download_count;
         const requestDetails = {
@@ -257,11 +258,17 @@ function EgressRequestList() {
             if (requestsApiResult.data.downloadData !== null) {
                 const presignUrl = requestsApiResult.data.downloadData.presign_url;
 
-                // Open presign_url link to download file
-                const downloadLink = document.createElement('a');
-                downloadLink.download = 'egress_data.zip';
-                downloadLink.href = presignUrl;
-                downloadLink.click();
+                if (copyToClipboard) {
+                    navigator.clipboard.writeText(presignUrl);
+                    setNotificationMessage('Link copied to clipboard');
+                    setOpenNotification(true);
+                } else {
+                    // Open presign_url link to download file
+                    const downloadLink = document.createElement('a');
+                    downloadLink.download = 'egress_data.zip';
+                    downloadLink.href = presignUrl;
+                    downloadLink.click();
+                }
                 selectedEgressRequest.download_count = Number(selectedEgressRequest.download_count) + 1;
                 setDownloading(false);
             } else {
@@ -272,6 +279,15 @@ function EgressRequestList() {
             setOpenNotification(true);
             setDownloading(false);
         }
+    };
+
+    // Make API call to download API
+    const handleDownload = async () => {
+        await handleDownloadOrCopy(false);
+    };
+
+    const handleCopyLink = async () => {
+        await handleDownloadOrCopy(true);
     };
 
     // Make API call to submit egress request review
@@ -622,6 +638,19 @@ function EgressRequestList() {
                                         startIcon={<FileDownloadIcon />}
                                     >
                                         Download
+                                    </Button>
+                                )}
+                                {downloading ? (
+                                    <CircularProgress size={25} color="primary" />
+                                ) : (
+                                    <Button
+                                        color="primary"
+                                        variant="contained"
+                                        onClick={handleCopyLink}
+                                        disabled={!isDownloadable}
+                                        startIcon={<ContentCopyIcon />}
+                                    >
+                                        Copy link
                                     </Button>
                                 )}
                             </Stack>


### PR DESCRIPTION
# Description

Add a `Copy link` button alongside the `Download` button (based on https://github.com/HicResearch/treehoose-egress-app-frontend/pull/11/commits/dfa75fcd24321d63d1ae7d592be711abcdc20c62)

![image](https://github.com/HicResearch/treehoose-egress-app-frontend/assets/1644105/0daa78a5-54ae-4c28-a562-5eb9dfe76405)

Also adds a GH workflow to run linting, and fixes the eslint config

- Closes https://github.com/HicResearch/treehoose-egress-app-frontend/pull/11
- Closes https://github.com/HicResearch/treehoose-egress-app-frontend/issues/17
----

Declaration : _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
