### PR TITLE
singleapprover: automatically make copy/download buttons available

### DIFF
--- a/src/components/egress/EgressRequestList.js
+++ b/src/components/egress/EgressRequestList.js
@@ -334,6 +334,10 @@ function EgressRequestList() {
                     }
                 }
                 setNotificationMessage('Request saved successfully.');
+                if (selectedEgressRequest.is_single_approval_enabled) {
+                    if (decision === 'APPROVED') setIsDownloadable(true);
+                    setIsEditable(false);
+                }
             } catch (err) {
                 setNotificationMessage(err.errors[0].message);
             }
@@ -627,32 +631,25 @@ function EgressRequestList() {
                                     Reject
                                 </Button>
 
-                                {downloading ? (
-                                    <CircularProgress size={25} color="primary" />
-                                ) : (
-                                    <Button
-                                        color="primary"
-                                        variant="contained"
-                                        onClick={handleDownload}
-                                        disabled={!isDownloadable}
-                                        startIcon={<FileDownloadIcon />}
-                                    >
-                                        Download
-                                    </Button>
-                                )}
-                                {downloading ? (
-                                    <CircularProgress size={25} color="primary" />
-                                ) : (
-                                    <Button
-                                        color="primary"
-                                        variant="contained"
-                                        onClick={handleCopyLink}
-                                        disabled={!isDownloadable}
-                                        startIcon={<ContentCopyIcon />}
-                                    >
-                                        Copy link
-                                    </Button>
-                                )}
+                                <Button
+                                    color="primary"
+                                    variant="contained"
+                                    onClick={handleDownload}
+                                    disabled={!isDownloadable}
+                                    startIcon={<FileDownloadIcon />}
+                                >
+                                    Download
+                                </Button>
+                                <Button
+                                    color="primary"
+                                    variant="contained"
+                                    onClick={handleCopyLink}
+                                    disabled={!isDownloadable}
+                                    startIcon={<ContentCopyIcon />}
+                                >
+                                    Copy link
+                                </Button>
+                                {downloading && <CircularProgress size={25} color="primary" />}
                             </Stack>
                         </MDBModalFooter>
                     </form>


### PR DESCRIPTION
# Description

Missed when porting https://github.com/HicResearch/treehoose-egress-app-frontend/pull/11 in https://github.com/HicResearch/treehoose-egress-app-frontend/pull/20

----

Declaration : _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
