### PR TITLE
Downgrade aws-amplify to 4.3.46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@material-ui/icons": "^4.11.3",
                 "@mui/icons-material": "^5.14.1",
                 "@mui/material": "^5.14.2",
-                "aws-amplify": "^5.3.5",
+                "aws-amplify": "^4.3.46",
                 "bootstrap-css-only": "4.4.1",
                 "env-cmd": "^10.1.0",
                 "mdbreact": "^5.2.0",
@@ -69,744 +69,9 @@
             }
         },
         "node_modules/@aws-amplify/analytics": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-6.4.1.tgz",
-            "integrity": "sha512-MDkkjCbDWtIqXHleJdLHbgRTi+XA4hFC3Fd4xQzozm4vCxs1SlQqr4HRkfx75iIhqd2IIfDad2/AiDehY9YIrQ==",
-            "dependencies": {
-                "@aws-amplify/cache": "5.1.5",
-                "@aws-amplify/core": "5.7.0",
-                "@aws-sdk/client-firehose": "3.6.1",
-                "@aws-sdk/client-kinesis": "3.6.1",
-                "@aws-sdk/client-personalize-events": "3.6.1",
-                "@aws-sdk/util-utf8-browser": "3.6.1",
-                "lodash": "^4.17.20",
-                "tslib": "^1.8.0",
-                "uuid": "^3.2.1"
-            }
-        },
-        "node_modules/@aws-amplify/analytics/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/api": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-5.3.5.tgz",
-            "integrity": "sha512-VoUmRJr76UnDmyafcfb5VSNrthJtPyNl0evEvjhyuj3jMGg/uiM8e6CGsteMfRtVW/y8nbu/SLz5Kxxiz7B5HQ==",
-            "dependencies": {
-                "@aws-amplify/api-graphql": "3.4.5",
-                "@aws-amplify/api-rest": "3.4.0",
-                "tslib": "^1.8.0"
-            }
-        },
-        "node_modules/@aws-amplify/api-graphql": {
-            "version": "3.4.5",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-3.4.5.tgz",
-            "integrity": "sha512-N14eHkKc06sP9010SxYAbcJBVNujNlHcmjnsZQIodM60sJEb9pqFf0xO9ngG5qTIYCX3UtEu5/267NUy6/xBiA==",
-            "dependencies": {
-                "@aws-amplify/api-rest": "3.4.0",
-                "@aws-amplify/auth": "5.5.5",
-                "@aws-amplify/cache": "5.1.5",
-                "@aws-amplify/core": "5.7.0",
-                "@aws-amplify/pubsub": "5.4.1",
-                "graphql": "15.8.0",
-                "tslib": "^1.8.0",
-                "uuid": "^3.2.1",
-                "zen-observable-ts": "0.8.19"
-            }
-        },
-        "node_modules/@aws-amplify/api-graphql/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/api-rest": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-3.4.0.tgz",
-            "integrity": "sha512-IsxJoz7WNFsHROZBjFA1A9EjpYNbiuzJzDVnhFYAf6HUEw2Cx9QSqSyatZU2sFi0kmT+Vx81K4xRFKCLpEeN+A==",
-            "dependencies": {
-                "@aws-amplify/core": "5.7.0",
-                "axios": "0.26.0",
-                "tslib": "^1.8.0",
-                "url": "0.11.0"
-            }
-        },
-        "node_modules/@aws-amplify/api-rest/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/api/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/auth": {
-            "version": "5.5.5",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.5.5.tgz",
-            "integrity": "sha512-W0cy//h62OXoWoVUMHJd4HW1wxKwEyyjDmNKBHLBs2FSAMUYujXl+8Rl17Z4UHOGYhV1UPx/LgoABOG7PxcyDw==",
-            "dependencies": {
-                "@aws-amplify/core": "5.7.0",
-                "amazon-cognito-identity-js": "6.3.1",
-                "tslib": "^1.8.0",
-                "url": "0.11.0"
-            }
-        },
-        "node_modules/@aws-amplify/auth/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/cache": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-5.1.5.tgz",
-            "integrity": "sha512-gOHZWsxjeySVMseOFRNe6CtRX/r1/j4gNvVSTWZeNCncvPB1X1iiQVtjKOCPxuY6X1DdmH65U1jnKxWV683tJQ==",
-            "dependencies": {
-                "@aws-amplify/core": "5.7.0",
-                "tslib": "^1.8.0"
-            }
-        },
-        "node_modules/@aws-amplify/cache/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/core": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.7.0.tgz",
-            "integrity": "sha512-P8dk4hmxm5XBtKI59XFjiUKUMIlzrgyGapnL3DAfE+twE8JEgRa7XtiffYy4drIXt7+Nl8tYyDhHlUI9/9I3Ow==",
-            "dependencies": {
-                "@aws-crypto/sha256-js": "1.2.2",
-                "@aws-sdk/client-cloudwatch-logs": "3.6.1",
-                "@aws-sdk/types": "3.6.1",
-                "@aws-sdk/util-hex-encoding": "3.6.1",
-                "@types/node-fetch": "2.6.4",
-                "isomorphic-unfetch": "^3.0.0",
-                "react-native-url-polyfill": "^1.3.0",
-                "tslib": "^1.8.0",
-                "universal-cookie": "^4.0.4",
-                "zen-observable-ts": "0.8.19"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/@jest/environment": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
-            "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
-            "peer": true,
-            "dependencies": {
-                "@jest/fake-timers": "^29.6.1",
-                "@jest/types": "^29.6.1",
-                "@types/node": "*",
-                "jest-mock": "^29.6.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/@jest/fake-timers": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
-            "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.1",
-                "@sinonjs/fake-timers": "^10.0.2",
-                "@types/node": "*",
-                "jest-message-util": "^29.6.1",
-                "jest-mock": "^29.6.1",
-                "jest-util": "^29.6.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/@jest/types": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
-            "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
-            "peer": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.0",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/@react-native/virtualized-lists": {
-            "version": "0.72.6",
-            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.72.6.tgz",
-            "integrity": "sha512-JhT6ydu35LvbSKdwnhWDuGHMOwM0WAh9oza/X8vXHA8ELHRyQ/4p8eKz/bTQcbQziJaaleUURToGhFuCtgiMoA==",
-            "peer": true,
-            "dependencies": {
-                "invariant": "^2.2.4",
-                "nullthrows": "^1.1.1"
-            },
-            "peerDependencies": {
-                "react-native": "*"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/@sinonjs/commons": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-            "peer": true,
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/@sinonjs/fake-timers": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-            "peer": true,
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/@types/yargs": {
-            "version": "17.0.24",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
-            "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
-            "peer": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "peer": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "peer": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "peer": true,
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "peer": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/core/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/jest-environment-node": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.1.tgz",
-            "integrity": "sha512-ZNIfAiE+foBog24W+2caIldl4Irh8Lx1PUhg/GZ0odM1d/h2qORAsejiFc7zb+SEmYPn1yDZzEDSU5PmDkmVLQ==",
-            "peer": true,
-            "dependencies": {
-                "@jest/environment": "^29.6.1",
-                "@jest/fake-timers": "^29.6.1",
-                "@jest/types": "^29.6.1",
-                "@types/node": "*",
-                "jest-mock": "^29.6.1",
-                "jest-util": "^29.6.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/jest-message-util": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
-            "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
-            "peer": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.12.13",
-                "@jest/types": "^29.6.1",
-                "@types/stack-utils": "^2.0.0",
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "micromatch": "^4.0.4",
-                "pretty-format": "^29.6.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/jest-message-util/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/jest-message-util/node_modules/pretty-format": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-            "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
-            "peer": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.0",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/jest-message-util/node_modules/react-is": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/core/node_modules/jest-mock": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
-            "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.1",
-                "@types/node": "*",
-                "jest-util": "^29.6.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/jest-util": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-            "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.1",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "graceful-fs": "^4.2.9",
-                "picomatch": "^2.2.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/pretty-format": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-            "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^26.6.2",
-                "ansi-regex": "^5.0.0",
-                "ansi-styles": "^4.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/pretty-format/node_modules/@jest/types": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-            "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-            "peer": true,
-            "dependencies": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 10.14.2"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/pretty-format/node_modules/@types/yargs": {
-            "version": "15.0.15",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
-            "integrity": "sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==",
-            "peer": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/react": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/react-native": {
-            "version": "0.72.3",
-            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.72.3.tgz",
-            "integrity": "sha512-QqISi+JVmCssNP2FlQ4MWhlc4O/I00MRE1/GClvyZ8h/6kdsyk/sOirkYdZqX3+DrJfI3q+OnyMnsyaXIQ/5tQ==",
-            "peer": true,
-            "dependencies": {
-                "@jest/create-cache-key-function": "^29.2.1",
-                "@react-native-community/cli": "11.3.5",
-                "@react-native-community/cli-platform-android": "11.3.5",
-                "@react-native-community/cli-platform-ios": "11.3.5",
-                "@react-native/assets-registry": "^0.72.0",
-                "@react-native/codegen": "^0.72.6",
-                "@react-native/gradle-plugin": "^0.72.11",
-                "@react-native/js-polyfills": "^0.72.1",
-                "@react-native/normalize-colors": "^0.72.0",
-                "@react-native/virtualized-lists": "^0.72.6",
-                "abort-controller": "^3.0.0",
-                "anser": "^1.4.9",
-                "base64-js": "^1.1.2",
-                "deprecated-react-native-prop-types": "4.1.0",
-                "event-target-shim": "^5.0.1",
-                "flow-enums-runtime": "^0.0.5",
-                "invariant": "^2.2.4",
-                "jest-environment-node": "^29.2.1",
-                "jsc-android": "^250231.0.0",
-                "memoize-one": "^5.0.0",
-                "metro-runtime": "0.76.7",
-                "metro-source-map": "0.76.7",
-                "mkdirp": "^0.5.1",
-                "nullthrows": "^1.1.1",
-                "pretty-format": "^26.5.2",
-                "promise": "^8.3.0",
-                "react-devtools-core": "^4.27.2",
-                "react-refresh": "^0.4.0",
-                "react-shallow-renderer": "^16.15.0",
-                "regenerator-runtime": "^0.13.2",
-                "scheduler": "0.24.0-canary-efb381bbf-20230505",
-                "stacktrace-parser": "^0.1.10",
-                "use-sync-external-store": "^1.0.0",
-                "whatwg-fetch": "^3.0.0",
-                "ws": "^6.2.2",
-                "yargs": "^17.6.2"
-            },
-            "bin": {
-                "react-native": "cli.js"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "peerDependencies": {
-                "react": "18.2.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/react-native-url-polyfill": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
-            "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
-            "dependencies": {
-                "whatwg-url-without-unicode": "8.0.0-3"
-            },
-            "peerDependencies": {
-                "react-native": "*"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/react-refresh": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
-            "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/scheduler": {
-            "version": "0.24.0-canary-efb381bbf-20230505",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.24.0-canary-efb381bbf-20230505.tgz",
-            "integrity": "sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "peer": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/core/node_modules/ws": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-            "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
-            "peer": true,
-            "dependencies": {
-                "async-limiter": "~1.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "peer": true,
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@aws-amplify/core/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@aws-amplify/datastore": {
-            "version": "4.6.5",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-4.6.5.tgz",
-            "integrity": "sha512-osWDuIzgA4jEL4P+xNdVMKCc0w0DrBlan38hDZyCqCjU+YiVV6DHqJMxC5XBIKcHAaan9uaO5PJZhtRi1VDM2w==",
-            "dependencies": {
-                "@aws-amplify/api": "5.3.5",
-                "@aws-amplify/auth": "5.5.5",
-                "@aws-amplify/core": "5.7.0",
-                "@aws-amplify/pubsub": "5.4.1",
-                "amazon-cognito-identity-js": "6.3.1",
-                "idb": "5.0.6",
-                "immer": "9.0.6",
-                "ulid": "2.3.0",
-                "uuid": "3.4.0",
-                "zen-observable-ts": "0.8.19",
-                "zen-push": "0.2.1"
-            }
-        },
-        "node_modules/@aws-amplify/geo": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/geo/-/geo-2.2.0.tgz",
-            "integrity": "sha512-9aXHQzebdHucp+XfJgMO+boys757M9EdGlylASSSjgWO3MsX4RhN0NUvpZ1L8VwbqPSeUBpTdJFv6YgtXCVxJQ==",
-            "dependencies": {
-                "@aws-amplify/core": "5.7.0",
-                "@aws-sdk/client-location": "3.186.3",
-                "@turf/boolean-clockwise": "6.5.0",
-                "camelcase-keys": "6.2.2",
-                "tslib": "^1.8.0"
-            }
-        },
-        "node_modules/@aws-amplify/geo/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/interactions": {
-            "version": "5.2.5",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-5.2.5.tgz",
-            "integrity": "sha512-iWgeO0Jy8CfLjTCSXWstAd5ZfYrn72r5db96DpFPU89VvK96vXeRDsPRh1DHnLa+DuCu6/m1698NpmaY1kiwUg==",
-            "dependencies": {
-                "@aws-amplify/core": "5.7.0",
-                "@aws-sdk/client-lex-runtime-service": "3.186.3",
-                "@aws-sdk/client-lex-runtime-v2": "3.186.3",
-                "base-64": "1.0.0",
-                "fflate": "0.7.3",
-                "pako": "2.0.4",
-                "tslib": "^1.8.0"
-            }
-        },
-        "node_modules/@aws-amplify/interactions/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/notifications": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-1.5.0.tgz",
-            "integrity": "sha512-O0+zdy/3pTv2PtrO7OhTQDS2rXiYVJRqze8nZrZls5oqiBEA/hLAlCOY9uw5QsnOkmcgMgyNsuyI0A5RCCGkjw==",
-            "dependencies": {
-                "@aws-amplify/cache": "5.1.5",
-                "@aws-amplify/core": "5.7.0",
-                "@aws-amplify/rtn-push-notification": "1.1.2",
-                "lodash": "^4.17.21",
-                "uuid": "^3.2.1"
-            }
-        },
-        "node_modules/@aws-amplify/predictions": {
-            "version": "5.4.5",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-5.4.5.tgz",
-            "integrity": "sha512-0cBQabxoN/7ZbPDqu1OByCaP83IKloe8N5lmo8lnwO//VCp9bPGG9V66dMyxN/wfHbISdOOSTrfwcs40t+2nZg==",
-            "dependencies": {
-                "@aws-amplify/core": "5.7.0",
-                "@aws-amplify/storage": "5.8.0",
-                "@aws-sdk/client-comprehend": "3.6.1",
-                "@aws-sdk/client-polly": "3.6.1",
-                "@aws-sdk/client-rekognition": "3.6.1",
-                "@aws-sdk/client-textract": "3.6.1",
-                "@aws-sdk/client-translate": "3.6.1",
-                "@aws-sdk/eventstream-marshaller": "3.6.1",
-                "@aws-sdk/util-utf8-node": "3.6.1",
-                "buffer": "4.9.2",
-                "tslib": "^1.8.0",
-                "uuid": "^3.2.1"
-            }
-        },
-        "node_modules/@aws-amplify/predictions/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/pubsub": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-5.4.1.tgz",
-            "integrity": "sha512-aFGD92vI4mtaMbLjjCAzUyq7z9ezaTZ9G74KJKl45hyL45ccCge5NEFHOHljcokbtrFiMqHKoJhI1q+rCB/UnA==",
-            "dependencies": {
-                "@aws-amplify/auth": "5.5.5",
-                "@aws-amplify/cache": "5.1.5",
-                "@aws-amplify/core": "5.7.0",
-                "graphql": "15.8.0",
-                "tslib": "^1.8.0",
-                "url": "0.11.0",
-                "uuid": "^3.2.1",
-                "zen-observable-ts": "0.8.19"
-            }
-        },
-        "node_modules/@aws-amplify/pubsub/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/rtn-push-notification": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/rtn-push-notification/-/rtn-push-notification-1.1.2.tgz",
-            "integrity": "sha512-hlqE76OLPljGFyZ8N6zOFf/yc6Svcc0gnjMVfN3liqlbsrA4u5eoeIi7iiMM/vUG9vCMKfu9rCfne2CQSBLyUA=="
-        },
-        "node_modules/@aws-amplify/storage": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-5.8.0.tgz",
-            "integrity": "sha512-o4sc78fKNOpZOQ3SFvI8ZjCJ2GCPrheC/6i982LvxLfpJfumeP7GvKiTpzKt1oGqtBrk59ARBnGcp5bI5KMWOA==",
-            "dependencies": {
-                "@aws-amplify/core": "5.7.0",
-                "@aws-sdk/md5-js": "3.6.1",
-                "@aws-sdk/types": "3.6.1",
-                "events": "^3.1.0",
-                "fast-xml-parser": "^4.2.5",
-                "tslib": "^1.8.0",
-                "typescript": "5.0.2"
-            }
-        },
-        "node_modules/@aws-amplify/storage/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-amplify/storage/node_modules/typescript": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=12.20"
-            }
-        },
-        "node_modules/@aws-amplify/ui": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.7.tgz",
-            "integrity": "sha512-tT7onRv+OCznFhUE2mKPpbGHHV+oODZk4VDX3lYNIfJ7LXv1hVtllQbPNJF5beNBRw9r6uotlXpeJrkph6v07A==",
-            "deprecated": "Versions '1.x' and '2.x' of '@aws-amplify/ui' have been deprecated. Please visit https://ui.docs.amplify.aws/ for the current version of Amplify UI.",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react": {
-            "version": "1.2.26",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.26.tgz",
-            "integrity": "sha512-GHKUewYORX7WH8jOrcTyst3B7j8+oj/bNLcEBrLMtbKUXBL9ui7z7LgsuTDVY9nrXb2HL3z1oc8gTEDbUJrtQA==",
-            "deprecated": "Version '1.x' of '@aws-amplify/ui-react' has been deprecated. Please visit https://ui.docs.amplify.aws/ for the current version of Amplify UI.",
-            "dependencies": {
-                "@aws-amplify/ui-components": "1.9.6"
-            },
-            "peerDependencies": {
-                "react": ">= 16.7.0",
-                "react-dom": ">= 16.7.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/analytics": {
             "version": "5.2.31",
             "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.2.31.tgz",
             "integrity": "sha512-u2j5qZRTDGD7d1TpbKU3D7928VFJK602537TWDuUibUCQWafCDLzPj1IJCiC6UdZ1yShqEmexa02/cqtq+gbwg==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/cache": "4.0.66",
                 "@aws-amplify/core": "4.7.15",
@@ -819,31 +84,19 @@
                 "uuid": "^3.2.1"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/analytics/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "peer": true,
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/api": {
+        "node_modules/@aws-amplify/api": {
             "version": "4.0.64",
             "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.64.tgz",
             "integrity": "sha512-nhg7Z+TQcEnLR5ZotxvKnJgqNwDtUYVBcNuktsHgUVszkKT/Oj2vC28xv8RufdljIofrXFsBDeERviwSpVXiFA==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/api-graphql": "2.3.28",
                 "@aws-amplify/api-rest": "2.0.64"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/api-graphql": {
+        "node_modules/@aws-amplify/api-graphql": {
             "version": "2.3.28",
             "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.3.28.tgz",
             "integrity": "sha512-n/8dwUx2i9sojcAnK1vITamx/FODGPmDM08lTfZNwpTVJ1aXB/bcA9GitF7gWa4jstVACDgQAKmTAr7j2d0tGw==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/api-rest": "2.0.64",
                 "@aws-amplify/auth": "4.6.17",
@@ -855,31 +108,19 @@
                 "zen-observable-ts": "0.8.19"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/api-graphql/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "peer": true,
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/api-rest": {
+        "node_modules/@aws-amplify/api-rest": {
             "version": "2.0.64",
             "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.64.tgz",
             "integrity": "sha512-hS+ImRnkyjGJj5gTet+Gd979Vnsp1lKTmiUngt3MXY/0b6CeUgMAACxnIQ628J00frvguUcgmOlZ502jeHsiKQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/core": "4.7.15",
                 "axios": "0.26.0"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/auth": {
+        "node_modules/@aws-amplify/auth": {
             "version": "4.6.17",
             "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.6.17.tgz",
             "integrity": "sha512-KIWHP6qODphwtzyJ6jmcSQewH0a8dOOsQ35OtAALwmPNEaftGmoUjm8wMHAtyH3EwWv1iknhPwMVzmGylr+l1A==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/cache": "4.0.66",
                 "@aws-amplify/core": "4.7.15",
@@ -887,20 +128,18 @@
                 "crypto-js": "^4.1.1"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/cache": {
+        "node_modules/@aws-amplify/cache": {
             "version": "4.0.66",
             "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.66.tgz",
             "integrity": "sha512-dG5TSx1VbUMnIchqwoT+Pa5W+PdPTZVcXfg/4bjpv0HJ0s3LUeYMI93cpQGg0DlegKNvwV5Ib+B7UqXlWp/JEQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/core": "4.7.15"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/core": {
+        "node_modules/@aws-amplify/core": {
             "version": "4.7.15",
             "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.7.15.tgz",
             "integrity": "sha512-upRxT6MN90pQZnJw2VwGdA7vHO6tGY1c3qLrXkq+x5XT45KrfGjbSSHmYBo7PkjWQYAUMGuX4KYwmPBuI58svg==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-js": "1.0.0-alpha.0",
                 "@aws-sdk/client-cloudwatch-logs": "3.6.1",
@@ -912,11 +151,41 @@
                 "zen-observable-ts": "0.8.19"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/datastore": {
+        "node_modules/@aws-amplify/core/node_modules/@aws-crypto/sha256-js": {
+            "version": "1.0.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0-alpha.0.tgz",
+            "integrity": "sha512-GidX2lccEtHZw8mXDKJQj6tea7qh3pAnsNSp1eZNxsN4MMu2OvSraPSqiB1EihsQkZBMg0IiZPpZHoACUX/QMQ==",
+            "dependencies": {
+                "@aws-sdk/types": "^1.0.0-alpha.0",
+                "@aws-sdk/util-utf8-browser": "^1.0.0-alpha.0",
+                "tslib": "^1.9.3"
+            }
+        },
+        "node_modules/@aws-amplify/core/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-rc.10.tgz",
+            "integrity": "sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ==",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-amplify/core/node_modules/@aws-sdk/util-utf8-browser": {
+            "version": "1.0.0-rc.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
+            "integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
+            "dependencies": {
+                "tslib": "^1.8.0"
+            }
+        },
+        "node_modules/@aws-amplify/core/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-amplify/datastore": {
             "version": "3.14.7",
             "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.14.7.tgz",
             "integrity": "sha512-nzZHK0LXOsvmZzeBHL8VL/nrTm9dmBYdOWZOf7zSrbZBVaLEMim2l2os3DUx0+1u44XPr166QSF8OXLpl+56+w==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/api": "4.0.64",
                 "@aws-amplify/auth": "4.6.17",
@@ -931,21 +200,19 @@
                 "zen-push": "0.2.1"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/datastore/node_modules/uuid": {
+        "node_modules/@aws-amplify/datastore/node_modules/uuid": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
             "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
             "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "peer": true,
             "bin": {
                 "uuid": "bin/uuid"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/geo": {
+        "node_modules/@aws-amplify/geo": {
             "version": "1.3.27",
             "resolved": "https://registry.npmjs.org/@aws-amplify/geo/-/geo-1.3.27.tgz",
             "integrity": "sha512-7ytYD0M3EJxq9aiqJVQSRoXXUYf/bp7MU2Bb+UvKjqxOb29theJp3RJ7yJnqjxAV+6K7+jRpjoqH8lR+y3zkwQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/core": "4.7.15",
                 "@aws-sdk/client-location": "3.186.0",
@@ -953,11 +220,10 @@
                 "camelcase-keys": "6.2.2"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/interactions": {
+        "node_modules/@aws-amplify/interactions": {
             "version": "4.1.12",
             "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.1.12.tgz",
             "integrity": "sha512-MQjq4wdGuA7DNRywMrlwjbWZ/b5VFP0ASZdMYWSGVVkjPpHKR+/iCy/kkJvUFXIl8kEXHlFQTidv4RiNd4sYdQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/core": "4.7.15",
                 "@aws-sdk/client-lex-runtime-service": "3.186.0",
@@ -967,11 +233,10 @@
                 "pako": "2.0.4"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/predictions": {
+        "node_modules/@aws-amplify/predictions": {
             "version": "4.0.64",
             "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.64.tgz",
             "integrity": "sha512-EcRwCqf0xFGoJLAzns7TIgKZxKZUlXubVPMTGIm9imVT/ZuF7ELX/YhIygzR33M+75rzLJxQcx5OOTFj6df/1Q==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/core": "4.7.15",
                 "@aws-amplify/storage": "4.5.17",
@@ -985,21 +250,10 @@
                 "uuid": "^3.2.1"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/predictions/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "peer": true,
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/pubsub": {
+        "node_modules/@aws-amplify/pubsub": {
             "version": "4.5.14",
             "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.5.14.tgz",
             "integrity": "sha512-WGR26nOMW2+DQE1DuWE4W9Ehx1RxmNmQN6Mq27DnKicLL0nMgyKT7OGBAHmQzVtsvMzFgUo/KcMBL3GltZ0M5g==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/auth": "4.6.17",
                 "@aws-amplify/cache": "4.0.66",
@@ -1010,21 +264,10 @@
                 "zen-observable-ts": "0.8.19"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/pubsub/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "peer": true,
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/storage": {
+        "node_modules/@aws-amplify/storage": {
             "version": "4.5.17",
             "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.5.17.tgz",
             "integrity": "sha512-GZJvTdZ8zjlSfQ32x4EY56sOTafL843s6geqd8d/ybpJYZqEyBpfbcLZnsZFStAEERBKB4hCyCs/m+E2zZg/xg==",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/core": "4.7.15",
                 "@aws-sdk/client-s3": "3.6.1",
@@ -1033,6 +276,25 @@
                 "@aws-sdk/util-format-url": "3.6.1",
                 "axios": "0.26.0",
                 "events": "^3.1.0"
+            }
+        },
+        "node_modules/@aws-amplify/ui": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.7.tgz",
+            "integrity": "sha512-tT7onRv+OCznFhUE2mKPpbGHHV+oODZk4VDX3lYNIfJ7LXv1hVtllQbPNJF5beNBRw9r6uotlXpeJrkph6v07A==",
+            "deprecated": "Versions '1.x' and '2.x' of '@aws-amplify/ui' have been deprecated. Please visit https://ui.docs.amplify.aws/ for the current version of Amplify UI."
+        },
+        "node_modules/@aws-amplify/ui-react": {
+            "version": "1.2.26",
+            "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-1.2.26.tgz",
+            "integrity": "sha512-GHKUewYORX7WH8jOrcTyst3B7j8+oj/bNLcEBrLMtbKUXBL9ui7z7LgsuTDVY9nrXb2HL3z1oc8gTEDbUJrtQA==",
+            "deprecated": "Version '1.x' of '@aws-amplify/ui-react' has been deprecated. Please visit https://ui.docs.amplify.aws/ for the current version of Amplify UI.",
+            "dependencies": {
+                "@aws-amplify/ui-components": "1.9.6"
+            },
+            "peerDependencies": {
+                "react": ">= 16.7.0",
+                "react-dom": ">= 16.7.0"
             }
         },
         "node_modules/@aws-amplify/ui-react/node_modules/@aws-amplify/ui-components": {
@@ -1048,1475 +310,6 @@
                 "aws-amplify": "3.x.x || 4.x.x"
             }
         },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/ie11-detection": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/sha256-browser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/ie11-detection": "^2.0.0",
-                "@aws-crypto/sha256-js": "^2.0.0",
-                "@aws-crypto/supports-web-crypto": "^2.0.0",
-                "@aws-crypto/util": "^2.0.0",
-                "@aws-sdk/types": "^3.1.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/sha256-js": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.2.tgz",
-            "integrity": "sha512-iXLdKH19qPmIC73fVCrHWCSYjN/sxaAvZ3jNNyw6FclmHyjLKg0f69WlC9KTnyElxCR5MO9SKaG00VwlJwyAkQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/util": "^2.0.2",
-                "@aws-sdk/types": "^3.110.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types": {
-            "version": "3.370.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
-            "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
-            "peer": true,
-            "dependencies": {
-                "@smithy/types": "^1.1.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types/node_modules/tslib": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-            "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/sha256-js": {
-            "version": "1.0.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0-alpha.0.tgz",
-            "integrity": "sha512-GidX2lccEtHZw8mXDKJQj6tea7qh3pAnsNSp1eZNxsN4MMu2OvSraPSqiB1EihsQkZBMg0IiZPpZHoACUX/QMQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "^1.0.0-alpha.0",
-                "@aws-sdk/util-utf8-browser": "^1.0.0-alpha.0",
-                "tslib": "^1.9.3"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-rc.10.tgz",
-            "integrity": "sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "1.0.0-rc.8",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
-            "integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^1.8.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/util": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-            "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "^3.110.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types": {
-            "version": "3.370.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
-            "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
-            "peer": true,
-            "dependencies": {
-                "@smithy/types": "^1.1.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types/node_modules/tslib": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-            "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-crypto/util/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/abort-controller": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.186.0.tgz",
-            "integrity": "sha512-JFvvvtEcbYOvVRRXasi64Dd1VcOz5kJmPvtzsJ+HzMHvPbGGs/aopOJAZQJMJttzJmJwVTay0QL6yag9Kk8nYA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/abort-controller/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-service": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-service/-/client-lex-runtime-service-3.186.0.tgz",
-            "integrity": "sha512-EgjQvFxa/o1urxpnWV2A/D0k4m763NqrPLuL074LR+cOkNxVl9W27aYL/tddDBmmDzzx4KcuRL6/n+UBZIheTg==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.186.0",
-                "@aws-sdk/config-resolver": "3.186.0",
-                "@aws-sdk/credential-provider-node": "3.186.0",
-                "@aws-sdk/fetch-http-handler": "3.186.0",
-                "@aws-sdk/hash-node": "3.186.0",
-                "@aws-sdk/invalid-dependency": "3.186.0",
-                "@aws-sdk/middleware-content-length": "3.186.0",
-                "@aws-sdk/middleware-host-header": "3.186.0",
-                "@aws-sdk/middleware-logger": "3.186.0",
-                "@aws-sdk/middleware-recursion-detection": "3.186.0",
-                "@aws-sdk/middleware-retry": "3.186.0",
-                "@aws-sdk/middleware-serde": "3.186.0",
-                "@aws-sdk/middleware-signing": "3.186.0",
-                "@aws-sdk/middleware-stack": "3.186.0",
-                "@aws-sdk/middleware-user-agent": "3.186.0",
-                "@aws-sdk/node-config-provider": "3.186.0",
-                "@aws-sdk/node-http-handler": "3.186.0",
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/smithy-client": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/url-parser": "3.186.0",
-                "@aws-sdk/util-base64-browser": "3.186.0",
-                "@aws-sdk/util-base64-node": "3.186.0",
-                "@aws-sdk/util-body-length-browser": "3.186.0",
-                "@aws-sdk/util-body-length-node": "3.186.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.186.0",
-                "@aws-sdk/util-defaults-mode-node": "3.186.0",
-                "@aws-sdk/util-user-agent-browser": "3.186.0",
-                "@aws-sdk/util-user-agent-node": "3.186.0",
-                "@aws-sdk/util-utf8-browser": "3.186.0",
-                "@aws-sdk/util-utf8-node": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-service/node_modules/@aws-crypto/sha256-js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/util": "^2.0.0",
-                "@aws-sdk/types": "^3.1.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-service/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-service/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-service/node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
-            "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-service/node_modules/@aws-sdk/util-utf8-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
-            "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-v2": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-v2/-/client-lex-runtime-v2-3.186.0.tgz",
-            "integrity": "sha512-oDN07yCWc9gsEYL44KSjPj8wdHHcf5Kti+w31fE7JHZqvRXxLsLx7G+kEcPmSTRk3Y4wDPXJozL6sDUAOAEb7A==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.186.0",
-                "@aws-sdk/config-resolver": "3.186.0",
-                "@aws-sdk/credential-provider-node": "3.186.0",
-                "@aws-sdk/eventstream-handler-node": "3.186.0",
-                "@aws-sdk/eventstream-serde-browser": "3.186.0",
-                "@aws-sdk/eventstream-serde-config-resolver": "3.186.0",
-                "@aws-sdk/eventstream-serde-node": "3.186.0",
-                "@aws-sdk/fetch-http-handler": "3.186.0",
-                "@aws-sdk/hash-node": "3.186.0",
-                "@aws-sdk/invalid-dependency": "3.186.0",
-                "@aws-sdk/middleware-content-length": "3.186.0",
-                "@aws-sdk/middleware-eventstream": "3.186.0",
-                "@aws-sdk/middleware-host-header": "3.186.0",
-                "@aws-sdk/middleware-logger": "3.186.0",
-                "@aws-sdk/middleware-recursion-detection": "3.186.0",
-                "@aws-sdk/middleware-retry": "3.186.0",
-                "@aws-sdk/middleware-serde": "3.186.0",
-                "@aws-sdk/middleware-signing": "3.186.0",
-                "@aws-sdk/middleware-stack": "3.186.0",
-                "@aws-sdk/middleware-user-agent": "3.186.0",
-                "@aws-sdk/node-config-provider": "3.186.0",
-                "@aws-sdk/node-http-handler": "3.186.0",
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/smithy-client": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/url-parser": "3.186.0",
-                "@aws-sdk/util-base64-browser": "3.186.0",
-                "@aws-sdk/util-base64-node": "3.186.0",
-                "@aws-sdk/util-body-length-browser": "3.186.0",
-                "@aws-sdk/util-body-length-node": "3.186.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.186.0",
-                "@aws-sdk/util-defaults-mode-node": "3.186.0",
-                "@aws-sdk/util-user-agent-browser": "3.186.0",
-                "@aws-sdk/util-user-agent-node": "3.186.0",
-                "@aws-sdk/util-utf8-browser": "3.186.0",
-                "@aws-sdk/util-utf8-node": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-v2/node_modules/@aws-crypto/sha256-js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/util": "^2.0.0",
-                "@aws-sdk/types": "^3.1.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-v2/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-v2/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-v2/node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
-            "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-lex-runtime-v2/node_modules/@aws-sdk/util-utf8-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
-            "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-location": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.186.0.tgz",
-            "integrity": "sha512-RXT1Z7jgYrPEdD1VkErH9Wm+z6y7c/ua1Pu9VQ8weu9vtD15S8Qnyd1m4HS8ZPQUUM/gTxs/fL9+s53wRWpfGQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.186.0",
-                "@aws-sdk/config-resolver": "3.186.0",
-                "@aws-sdk/credential-provider-node": "3.186.0",
-                "@aws-sdk/fetch-http-handler": "3.186.0",
-                "@aws-sdk/hash-node": "3.186.0",
-                "@aws-sdk/invalid-dependency": "3.186.0",
-                "@aws-sdk/middleware-content-length": "3.186.0",
-                "@aws-sdk/middleware-host-header": "3.186.0",
-                "@aws-sdk/middleware-logger": "3.186.0",
-                "@aws-sdk/middleware-recursion-detection": "3.186.0",
-                "@aws-sdk/middleware-retry": "3.186.0",
-                "@aws-sdk/middleware-serde": "3.186.0",
-                "@aws-sdk/middleware-signing": "3.186.0",
-                "@aws-sdk/middleware-stack": "3.186.0",
-                "@aws-sdk/middleware-user-agent": "3.186.0",
-                "@aws-sdk/node-config-provider": "3.186.0",
-                "@aws-sdk/node-http-handler": "3.186.0",
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/smithy-client": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/url-parser": "3.186.0",
-                "@aws-sdk/util-base64-browser": "3.186.0",
-                "@aws-sdk/util-base64-node": "3.186.0",
-                "@aws-sdk/util-body-length-browser": "3.186.0",
-                "@aws-sdk/util-body-length-node": "3.186.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.186.0",
-                "@aws-sdk/util-defaults-mode-node": "3.186.0",
-                "@aws-sdk/util-user-agent-browser": "3.186.0",
-                "@aws-sdk/util-user-agent-node": "3.186.0",
-                "@aws-sdk/util-utf8-browser": "3.186.0",
-                "@aws-sdk/util-utf8-node": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-location/node_modules/@aws-crypto/sha256-js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/util": "^2.0.0",
-                "@aws-sdk/types": "^3.1.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-location/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
-            "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-location/node_modules/@aws-sdk/util-utf8-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
-            "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-sts": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
-            "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.186.0",
-                "@aws-sdk/credential-provider-node": "3.186.0",
-                "@aws-sdk/fetch-http-handler": "3.186.0",
-                "@aws-sdk/hash-node": "3.186.0",
-                "@aws-sdk/invalid-dependency": "3.186.0",
-                "@aws-sdk/middleware-content-length": "3.186.0",
-                "@aws-sdk/middleware-host-header": "3.186.0",
-                "@aws-sdk/middleware-logger": "3.186.0",
-                "@aws-sdk/middleware-recursion-detection": "3.186.0",
-                "@aws-sdk/middleware-retry": "3.186.0",
-                "@aws-sdk/middleware-sdk-sts": "3.186.0",
-                "@aws-sdk/middleware-serde": "3.186.0",
-                "@aws-sdk/middleware-signing": "3.186.0",
-                "@aws-sdk/middleware-stack": "3.186.0",
-                "@aws-sdk/middleware-user-agent": "3.186.0",
-                "@aws-sdk/node-config-provider": "3.186.0",
-                "@aws-sdk/node-http-handler": "3.186.0",
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/smithy-client": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/url-parser": "3.186.0",
-                "@aws-sdk/util-base64-browser": "3.186.0",
-                "@aws-sdk/util-base64-node": "3.186.0",
-                "@aws-sdk/util-body-length-browser": "3.186.0",
-                "@aws-sdk/util-body-length-node": "3.186.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.186.0",
-                "@aws-sdk/util-defaults-mode-node": "3.186.0",
-                "@aws-sdk/util-user-agent-browser": "3.186.0",
-                "@aws-sdk/util-user-agent-node": "3.186.0",
-                "@aws-sdk/util-utf8-browser": "3.186.0",
-                "@aws-sdk/util-utf8-node": "3.186.0",
-                "entities": "2.2.0",
-                "fast-xml-parser": "3.19.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/util": "^2.0.0",
-                "@aws-sdk/types": "^3.1.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
-            "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-utf8-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
-            "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/config-resolver": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.186.0.tgz",
-            "integrity": "sha512-l8DR7Q4grEn1fgo2/KvtIfIHJS33HGKPQnht8OPxkl0dMzOJ0jxjOw/tMbrIcPnr2T3Fi7LLcj3dY1Fo1poruQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/signature-v4": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/util-config-provider": "3.186.0",
-                "@aws-sdk/util-middleware": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.186.0.tgz",
-            "integrity": "sha512-N9LPAqi1lsQWgxzmU4NPvLPnCN5+IQ3Ai1IFf3wM6FFPNoSUd1kIA2c6xaf0BE7j5Kelm0raZOb4LnV3TBAv+g==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-imds": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.186.0.tgz",
-            "integrity": "sha512-iJeC7KrEgPPAuXjCZ3ExYZrRQvzpSdTZopYgUm5TnNZ8S1NU/4nvv5xVy61JvMj3JQAeG8UDYYgC421Foc8wQw==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/node-config-provider": "3.186.0",
-                "@aws-sdk/property-provider": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/url-parser": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.186.0.tgz",
-            "integrity": "sha512-ecrFh3MoZhAj5P2k/HXo/hMJQ3sfmvlommzXuZ/D1Bj2yMcyWuBhF1A83Fwd2gtYrWRrllsK3IOMM5Jr8UIVZA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.186.0",
-                "@aws-sdk/credential-provider-imds": "3.186.0",
-                "@aws-sdk/credential-provider-sso": "3.186.0",
-                "@aws-sdk/credential-provider-web-identity": "3.186.0",
-                "@aws-sdk/property-provider": "3.186.0",
-                "@aws-sdk/shared-ini-file-loader": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.186.0.tgz",
-            "integrity": "sha512-HIt2XhSRhEvVgRxTveLCzIkd/SzEBQfkQ6xMJhkBtfJw1o3+jeCk+VysXM0idqmXytctL0O3g9cvvTHOsUgxOA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.186.0",
-                "@aws-sdk/credential-provider-imds": "3.186.0",
-                "@aws-sdk/credential-provider-ini": "3.186.0",
-                "@aws-sdk/credential-provider-process": "3.186.0",
-                "@aws-sdk/credential-provider-sso": "3.186.0",
-                "@aws-sdk/credential-provider-web-identity": "3.186.0",
-                "@aws-sdk/property-provider": "3.186.0",
-                "@aws-sdk/shared-ini-file-loader": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz",
-            "integrity": "sha512-ATRU6gbXvWC1TLnjOEZugC/PBXHBoZgBADid4fDcEQY1vF5e5Ux1kmqkJxyHtV5Wl8sE2uJfwWn+FlpUHRX67g==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.186.0",
-                "@aws-sdk/shared-ini-file-loader": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/eventstream-serde-browser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.186.0.tgz",
-            "integrity": "sha512-0r2c+yugBdkP5bglGhGOgztjeHdHTKqu2u6bvTByM0nJShNO9YyqWygqPqDUOE5axcYQE1D0aFDGzDtP3mGJhw==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/eventstream-serde-universal": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.186.0.tgz",
-            "integrity": "sha512-xhwCqYrAX5c7fg9COXVw6r7Sa3BO5cCfQMSR5S1QisE7do8K1GDKEHvUCheOx+RLon+P3glLjuNBMdD0HfCVNA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/eventstream-serde-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.186.0.tgz",
-            "integrity": "sha512-9p/gdukJYfmA+OEYd6MfIuufxrrfdt15lBDM3FODuc9j09LSYSRHSxthkIhiM5XYYaaUM+4R0ZlSMdaC3vFDFQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/eventstream-serde-universal": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/eventstream-serde-universal": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.186.0.tgz",
-            "integrity": "sha512-rIgPmwUxn2tzainBoh+cxAF+b7o01CcW+17yloXmawsi0kiR7QK7v9m/JTGQPWKtHSsPOrtRzuiWQNX57SlcsQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/eventstream-codec": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/fetch-http-handler": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.186.0.tgz",
-            "integrity": "sha512-k2v4AAHRD76WnLg7arH94EvIclClo/YfuqO7NoQ6/KwOxjRhs4G6TgIsAZ9E0xmqoJoV81Xqy8H8ldfy9F8LEw==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/querystring-builder": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/util-base64-browser": "3.186.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/hash-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.186.0.tgz",
-            "integrity": "sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/util-buffer-from": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/invalid-dependency": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.186.0.tgz",
-            "integrity": "sha512-hjeZKqORhG2DPWYZ776lQ9YO3gjw166vZHZCZU/43kEYaCZHsF4mexHwHzreAY6RfS25cH60Um7dUh1aeVIpkw==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/invalid-dependency/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/is-array-buffer": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.186.0.tgz",
-            "integrity": "sha512-fObm+P6mjWYzxoFY4y2STHBmSdgKbIAXez0xope563mox62I8I4hhVPUCaDVydXvDpJv8tbedJMk0meJl22+xA==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-content-length": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
-            "integrity": "sha512-Ol3c1ks3IK1s+Okc/rHIX7w2WpXofuQdoAEme37gHeml+8FtUlWH/881h62xfMdf+0YZpRuYv/eM7lBmJBPNJw==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.186.0.tgz",
-            "integrity": "sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.186.0.tgz",
-            "integrity": "sha512-/1gGBImQT8xYh80pB7QtyzA799TqXtLZYQUohWAsFReYB7fdh5o+mu2rX0FNzZnrLIh2zBUNs4yaWGsnab4uXg==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-retry": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.186.0.tgz",
-            "integrity": "sha512-/VI9emEKhhDzlNv9lQMmkyxx3GjJ8yPfXH3HuAeOgM1wx1BjCTLRYEWnTbQwq7BDzVENdneleCsGAp7yaj80Aw==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/service-error-classification": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/util-middleware": "3.186.0",
-                "tslib": "^2.3.1",
-                "uuid": "^8.3.2"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.186.0.tgz",
-            "integrity": "sha512-6FEAz70RNf18fKL5O7CepPSwTKJEIoyG9zU6p17GzKMgPeFsxS5xO94Hcq5tV2/CqeHliebjqhKY7yi+Pgok7g==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-serde/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.186.0.tgz",
-            "integrity": "sha512-riCJYG/LlF/rkgVbHkr4xJscc0/sECzDivzTaUmfb9kJhAwGxCyNqnTvg0q6UO00kxSdEB9zNZI2/iJYVBijBQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.186.0",
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/signature-v4": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/util-middleware": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.186.0.tgz",
-            "integrity": "sha512-fENMoo0pW7UBrbuycPf+3WZ+fcUgP9PnQ0jcOK3WWZlZ9d2ewh4HNxLh4EE3NkNYj4VIUFXtTUuVNHlG8trXjQ==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.186.0.tgz",
-            "integrity": "sha512-fb+F2PF9DLKOVMgmhkr+ltN8ZhNJavTla9aqmbd01846OLEaN1n5xEnV7p8q5+EznVBWDF38Oz9Ae5BMt3Hs7w==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/node-config-provider": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz",
-            "integrity": "sha512-De93mgmtuUUeoiKXU8pVHXWKPBfJQlS/lh1k2H9T2Pd9Tzi0l7p5ttddx4BsEx4gk+Pc5flNz+DeptiSjZpa4A==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.186.0",
-                "@aws-sdk/shared-ini-file-loader": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.186.0.tgz",
-            "integrity": "sha512-CbkbDuPZT9UNJ4dAZJWB3BV+Z65wFy7OduqGkzNNrKq6ZYMUfehthhUOTk8vU6RMe/0FkN+J0fFXlBx/bs/cHw==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/abort-controller": "3.186.0",
-                "@aws-sdk/protocol-http": "3.186.0",
-                "@aws-sdk/querystring-builder": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/property-provider": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.186.0.tgz",
-            "integrity": "sha512-nWKqt36UW3xV23RlHUmat+yevw9up+T+953nfjcmCBKtgWlCWu/aUzewTRhKj3VRscbN+Wer95SBw9Lr/MMOlQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/property-provider/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/protocol-http": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.186.0.tgz",
-            "integrity": "sha512-l/KYr/UBDUU5ginqTgHtFfHR3X6ljf/1J1ThIiUg3C3kVC/Zwztm7BEOw8hHRWnWQGU/jYasGYcrcPLdQqFZyQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/protocol-http/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/querystring-builder": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.186.0.tgz",
-            "integrity": "sha512-mweCpuLufImxfq/rRBTEpjGuB4xhQvbokA+otjnUxlPdIobytLqEs7pCGQfLzQ7+1ZMo8LBXt70RH4A2nSX/JQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/util-uri-escape": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.186.0.tgz",
-            "integrity": "sha512-0iYfEloghzPVXJjmnzHamNx1F1jIiTW9Svy5ZF9LVqyr/uHZcQuiWYsuhWloBMLs8mfWarkZM02WfxZ8buAuhg==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/querystring-parser/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/service-error-classification": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz",
-            "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/shared-ini-file-loader": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.186.0.tgz",
-            "integrity": "sha512-2FZqxmICtwN9CYid4dwfJSz/gGFHyStFQ3HCOQ8DsJUf2yREMSBsVmKqsyWgOrYcQ98gPcD5GIa7QO5yl3XF6A==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/shared-ini-file-loader/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/signature-v4": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz",
-            "integrity": "sha512-18i96P5c4suMqwSNhnEOqhq4doqqyjH4fn0YV3F8TkekHPIWP4mtIJ0PWAN4eievqdtcKgD/GqVO6FaJG9texw==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/is-array-buffer": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "@aws-sdk/util-hex-encoding": "3.186.0",
-                "@aws-sdk/util-middleware": "3.186.0",
-                "@aws-sdk/util-uri-escape": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/util-hex-encoding": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.186.0.tgz",
-            "integrity": "sha512-UL9rdgIZz1E/jpAfaKH8QgUxNK9VP5JPgoR0bSiaefMjnsoBh0x/VVMsfUyziOoJCMLebhJzFowtwrSKEGsxNg==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/smithy-client": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.186.0.tgz",
-            "integrity": "sha512-rdAxSFGSnrSprVJ6i1BXi65r4X14cuya6fYe8dSdgmFSa+U2ZevT97lb3tSINCUxBGeMXhENIzbVGkRZuMh+DQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/middleware-stack": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/smithy-client/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/url-parser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.186.0.tgz",
-            "integrity": "sha512-jfdJkKqJZp8qjjwEjIGDqbqTuajBsddw02f86WiL8bPqD8W13/hdqbG4Fpwc+Bm6GwR6/4MY6xWXFnk8jDUKeA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/querystring-parser": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/url-parser/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-base64-browser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.186.0.tgz",
-            "integrity": "sha512-TpQL8opoFfzTwUDxKeon/vuc83kGXpYqjl6hR8WzmHoQgmFfdFlV+0KXZOohra1001OP3FhqvMqaYbO8p9vXVQ==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-base64-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.186.0.tgz",
-            "integrity": "sha512-wH5Y/EQNBfGS4VkkmiMyZXU+Ak6VCoFM1GKWopV+sj03zR2D4FHexi4SxWwEBMpZCd6foMtihhbNBuPA5fnh6w==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-body-length-browser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz",
-            "integrity": "sha512-zKtjkI/dkj9oGkjo+7fIz+I9KuHrVt1ROAeL4OmDESS8UZi3/O8uMDFMuCp8jft6H+WFuYH6qRVWAVwXMiasXw==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-body-length-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.186.0.tgz",
-            "integrity": "sha512-U7Ii8u8Wvu9EnBWKKeuwkdrWto3c0j7LG677Spe6vtwWkvY70n9WGfiKHTgBpVeLNv8jvfcx5+H0UOPQK1o9SQ==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-buffer-from": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.186.0.tgz",
-            "integrity": "sha512-be2GCk2lsLWg/2V5Y+S4/9pOMXhOQo4DR4dIqBdR2R+jrMMHN9Xsr5QrkT6chcqLaJ/SBlwiAEEi3StMRmCOXA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/is-array-buffer": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-uri-escape": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.186.0.tgz",
-            "integrity": "sha512-imtOrJFpIZAipAg8VmRqYwv1G/x4xzyoxOJ48ZSn1/ZGnKEEnB6n6E9gwYRebi4mlRuMSVeZwCPLq0ey5hReeQ==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.186.0.tgz",
-            "integrity": "sha512-fbRcTTutMk4YXY3A2LePI4jWSIeHOT8DaYavpc/9Xshz/WH9RTGMmokeVOcClRNBeDSi5cELPJJ7gx6SFD3ZlQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.186.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.186.0.tgz",
-            "integrity": "sha512-oWZR7hN6NtOgnT6fUvHaafgbipQc2xJCRB93XHiF9aZGptGNLJzznIOP7uURdn0bTnF73ejbUXWLQIm8/6ue6w==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/node-config-provider": "3.186.0",
-                "@aws-sdk/types": "3.186.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-            "version": "3.186.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-            "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/amazon-cognito-identity-js": {
-            "version": "5.2.14",
-            "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.14.tgz",
-            "integrity": "sha512-9LMgLZfbypbbGTpARQ+QqglE09b1MWti11NXhcD/wPom0uhU/L90dfmUOpTwknz//eE6/dGYf004mJucWzrfxQ==",
-            "peer": true,
-            "dependencies": {
-                "buffer": "4.9.2",
-                "crypto-js": "^4.1.1",
-                "fast-base64-decode": "^1.0.0",
-                "isomorphic-unfetch": "^3.0.0",
-                "js-cookie": "^2.2.1"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/aws-amplify": {
-            "version": "4.3.46",
-            "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.46.tgz",
-            "integrity": "sha512-LygkBq+mrV+hFf3DCrVcyYNxFsiYwL0HLN89X1Eg+s3f7df6T2xpjh4JuaDJFbmodEdAlZNfdtRGLMk6ApnPcA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-amplify/analytics": "5.2.31",
-                "@aws-amplify/api": "4.0.64",
-                "@aws-amplify/auth": "4.6.17",
-                "@aws-amplify/cache": "4.0.66",
-                "@aws-amplify/core": "4.7.15",
-                "@aws-amplify/datastore": "3.14.7",
-                "@aws-amplify/geo": "1.3.27",
-                "@aws-amplify/interactions": "4.1.12",
-                "@aws-amplify/predictions": "4.0.64",
-                "@aws-amplify/pubsub": "4.5.14",
-                "@aws-amplify/storage": "4.5.17",
-                "@aws-amplify/ui": "2.0.7",
-                "@aws-amplify/xr": "3.0.64"
-            }
-        },
-        "node_modules/@aws-amplify/ui-react/node_modules/fast-xml-parser": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
-            "peer": true,
-            "bin": {
-                "xml2js": "cli.js"
-            },
-            "funding": {
-                "type": "paypal",
-                "url": "https://paypal.me/naturalintelligence"
-            }
-        },
         "node_modules/@aws-amplify/ui-react/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -2530,61 +323,9 @@
             "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.64.tgz",
             "integrity": "sha512-YZJbHVEU9uN8yKHms2uIWyikUPEj4go6qL40vcIDwCv9LNyer2lP+yZ1Djn1FFhqUgLi5lK+yh4PUCoqPUWE8w==",
             "deprecated": "The Amazon Sumerian service is no longer accepting new customers. Existing customer scenes will not be available after February 21, 2023. The AWS Amplify XR features depend on the Amazon Sumerian service to function and as a result, will no longer be available.",
-            "peer": true,
             "dependencies": {
                 "@aws-amplify/core": "4.7.15"
             }
-        },
-        "node_modules/@aws-amplify/xr/node_modules/@aws-amplify/core": {
-            "version": "4.7.15",
-            "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.7.15.tgz",
-            "integrity": "sha512-upRxT6MN90pQZnJw2VwGdA7vHO6tGY1c3qLrXkq+x5XT45KrfGjbSSHmYBo7PkjWQYAUMGuX4KYwmPBuI58svg==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-js": "1.0.0-alpha.0",
-                "@aws-sdk/client-cloudwatch-logs": "3.6.1",
-                "@aws-sdk/client-cognito-identity": "3.6.1",
-                "@aws-sdk/credential-provider-cognito-identity": "3.6.1",
-                "@aws-sdk/types": "3.6.1",
-                "@aws-sdk/util-hex-encoding": "3.6.1",
-                "universal-cookie": "^4.0.4",
-                "zen-observable-ts": "0.8.19"
-            }
-        },
-        "node_modules/@aws-amplify/xr/node_modules/@aws-crypto/sha256-js": {
-            "version": "1.0.0-alpha.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0-alpha.0.tgz",
-            "integrity": "sha512-GidX2lccEtHZw8mXDKJQj6tea7qh3pAnsNSp1eZNxsN4MMu2OvSraPSqiB1EihsQkZBMg0IiZPpZHoACUX/QMQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/types": "^1.0.0-alpha.0",
-                "@aws-sdk/util-utf8-browser": "^1.0.0-alpha.0",
-                "tslib": "^1.9.3"
-            }
-        },
-        "node_modules/@aws-amplify/xr/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
-            "version": "1.0.0-rc.10",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-rc.10.tgz",
-            "integrity": "sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ==",
-            "peer": true,
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-amplify/xr/node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "1.0.0-rc.8",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
-            "integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
-            "peer": true,
-            "dependencies": {
-                "tslib": "^1.8.0"
-            }
-        },
-        "node_modules/@aws-amplify/xr/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
         },
         "node_modules/@aws-crypto/crc32": {
             "version": "2.0.0",
@@ -2607,11 +348,11 @@
             }
         },
         "node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
-            "version": "3.370.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
-            "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+            "version": "3.449.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.449.0.tgz",
+            "integrity": "sha512-tSQPAvknheB6XnRoc+AuEgdzn2KhY447hddeVW0Mbg8Yl9es4u4TKVINloKDEyUrCKhB/1f93Hb5uJkPe/e/Ww==",
             "dependencies": {
-                "@smithy/types": "^1.1.0",
+                "@smithy/types": "^2.4.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -2619,9 +360,9 @@
             }
         },
         "node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types/node_modules/tslib": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-            "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-crypto/crc32/node_modules/tslib": {
             "version": "1.14.1",
@@ -2724,7 +465,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.6.1.tgz",
             "integrity": "sha512-QBGUBoD8D5nsM/EKoc0rjpApa5NE5pQVzw1caE8sG00QMMPkCXWSB/gTVKVY0GOAhJFoA/VpVPQchIlZcOrBFg==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^1.8.0"
             }
@@ -2733,7 +473,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.6.1.tgz",
             "integrity": "sha512-vP6bc2v9h442Srmo7t2QcIbPjk5IqLSf4jGnKDAes8z+7eyjCtKugRP3lOM1fJCfGlPIsJGYnexxYdEGw008vA==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/util-base64-browser": "3.6.1",
                 "tslib": "^1.8.0"
@@ -2742,14 +481,12 @@
         "node_modules/@aws-sdk/chunked-blob-reader-native/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/chunked-blob-reader/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/client-cloudwatch-logs": {
             "version": "3.6.1",
@@ -2796,7 +533,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.6.1.tgz",
             "integrity": "sha512-FMj2GR9R5oCKb3/NI16GIvWeHcE4uX42fBAaQKPbjg2gALFDx9CcJYsdOtDP37V89GtPyZilLv6GJxrwJKzYGg==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "^1.0.0",
                 "@aws-crypto/sha256-js": "^1.0.0",
@@ -2963,13 +699,13 @@
             }
         },
         "node_modules/@aws-sdk/client-lex-runtime-service": {
-            "version": "3.186.3",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-service/-/client-lex-runtime-service-3.186.3.tgz",
-            "integrity": "sha512-YP+GDY9OxyW4rJDqjreaNpiDBvH1uzO3ShJKl57hT92Kw2auDQxttcMf//J8dQXvrVkW/fVXCLI9TmtxS7XJOQ==",
+            "version": "3.186.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-service/-/client-lex-runtime-service-3.186.0.tgz",
+            "integrity": "sha512-EgjQvFxa/o1urxpnWV2A/D0k4m763NqrPLuL074LR+cOkNxVl9W27aYL/tddDBmmDzzx4KcuRL6/n+UBZIheTg==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.186.3",
+                "@aws-sdk/client-sts": "3.186.0",
                 "@aws-sdk/config-resolver": "3.186.0",
                 "@aws-sdk/credential-provider-node": "3.186.0",
                 "@aws-sdk/fetch-http-handler": "3.186.0",
@@ -3618,13 +1354,13 @@
             }
         },
         "node_modules/@aws-sdk/client-lex-runtime-v2": {
-            "version": "3.186.3",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-v2/-/client-lex-runtime-v2-3.186.3.tgz",
-            "integrity": "sha512-4MJfSnb+qM8BYW4ToCvg7sDWN0NcEqK738hCZUV89cjp7pIHZ6osJuS/PsmZEommVj+71GviZ4buu5KUCfCGFQ==",
+            "version": "3.186.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-v2/-/client-lex-runtime-v2-3.186.0.tgz",
+            "integrity": "sha512-oDN07yCWc9gsEYL44KSjPj8wdHHcf5Kti+w31fE7JHZqvRXxLsLx7G+kEcPmSTRk3Y4wDPXJozL6sDUAOAEb7A==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.186.3",
+                "@aws-sdk/client-sts": "3.186.0",
                 "@aws-sdk/config-resolver": "3.186.0",
                 "@aws-sdk/credential-provider-node": "3.186.0",
                 "@aws-sdk/eventstream-handler-node": "3.186.0",
@@ -4329,13 +2065,13 @@
             }
         },
         "node_modules/@aws-sdk/client-location": {
-            "version": "3.186.3",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.186.3.tgz",
-            "integrity": "sha512-LCMFgoWfvKBnZhhtl93RLhrsHCalM7huaxErHSKoqWDBUDP0i7rOX73qW8E25j/vQ4emEkT0d6ts1rDu4EnlNw==",
+            "version": "3.186.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.186.0.tgz",
+            "integrity": "sha512-RXT1Z7jgYrPEdD1VkErH9Wm+z6y7c/ua1Pu9VQ8weu9vtD15S8Qnyd1m4HS8ZPQUUM/gTxs/fL9+s53wRWpfGQ==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.186.3",
+                "@aws-sdk/client-sts": "3.186.0",
                 "@aws-sdk/config-resolver": "3.186.0",
                 "@aws-sdk/credential-provider-node": "3.186.0",
                 "@aws-sdk/fetch-http-handler": "3.186.0",
@@ -5028,7 +2764,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-pinpoint/-/client-pinpoint-3.6.1.tgz",
             "integrity": "sha512-dueBedp91EKAHxcWLR3aNx/eUEdxdF9niEQTzOO2O4iJL2yvO2Hh7ZYiO7B3g7FuuICTpWSHd//Y9mGmSVLMCg==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "^1.0.0",
                 "@aws-crypto/sha256-js": "^1.0.0",
@@ -5153,7 +2888,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.6.1.tgz",
             "integrity": "sha512-59cTmZj92iwgNoAeJirK5sZNQNXLc/oI3luqrEHRNLuOh70bjdgad70T0a5k2Ysd/v/QNamqJxnCJMPuX1bhgw==",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "^1.0.0",
                 "@aws-crypto/sha256-js": "^1.0.0",
@@ -5210,7 +2944,6 @@
             "version": "3.21.1",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
             "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
-            "peer": true,
             "dependencies": {
                 "strnum": "^1.0.4"
             },
@@ -5779,9 +3512,9 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.186.3",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.3.tgz",
-            "integrity": "sha512-mnttdyYBtqO+FkDtOT3F1FGi8qD11fF5/3zYLaNuFFULqKneaIwW2YIsjFlgvPGpmoyo/tNplnZwhQ9xQtT3Sw==",
+            "version": "3.186.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
+            "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -5817,7 +3550,7 @@
                 "@aws-sdk/util-utf8-browser": "3.186.0",
                 "@aws-sdk/util-utf8-node": "3.186.0",
                 "entities": "2.2.0",
-                "fast-xml-parser": "4.2.5",
+                "fast-xml-parser": "3.19.0",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -6428,24 +4161,15 @@
             }
         },
         "node_modules/@aws-sdk/client-sts/node_modules/fast-xml-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-            "funding": [
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/naturalintelligence"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "dependencies": {
-                "strnum": "^1.0.5"
-            },
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
             "bin": {
-                "fxparser": "src/cli/cli.js"
+                "xml2js": "cli.js"
+            },
+            "funding": {
+                "type": "paypal",
+                "url": "https://paypal.me/naturalintelligence"
             }
         },
         "node_modules/@aws-sdk/client-sts/node_modules/uuid": {
@@ -6561,7 +4285,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.6.1.tgz",
             "integrity": "sha512-uJ9q+yq+Dhdo32gcv0p/AT7sKSAUH0y4ts9XRK/vx0dW9Q3XJy99mOJlq/6fkh4LfWeavJJlaCo9lSHNMWXx4w==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/client-cognito-identity": "3.6.1",
                 "@aws-sdk/property-provider": "3.6.1",
@@ -6575,8 +4298,7 @@
         "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.6.1",
@@ -6927,7 +4649,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.6.1.tgz",
             "integrity": "sha512-9jPaZ/e3F8gf9JZd44DD6MvbYV6bKnn99rkG3GFIINOy9etoxPrLehp2bH2DK/j0ow60RNuwgUjj5qHV/zF67g==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/chunked-blob-reader": "3.6.1",
                 "@aws-sdk/chunked-blob-reader-native": "3.6.1",
@@ -6938,8 +4659,7 @@
         "node_modules/@aws-sdk/hash-blob-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/hash-node": {
             "version": "3.6.1",
@@ -6963,7 +4683,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.6.1.tgz",
             "integrity": "sha512-ePaWjCItIWxuSxA/UnUM/keQ3IAOsQz3FYSxu0KK8K0e1bKTEUgDIG9oMLBq7jIl9TzJG0HBXuPfMe73QHUNug==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.6.1",
                 "tslib": "^1.8.0"
@@ -6975,8 +4694,7 @@
         "node_modules/@aws-sdk/hash-stream-node/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/invalid-dependency": {
             "version": "3.6.1",
@@ -7027,7 +4745,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.6.1.tgz",
             "integrity": "sha512-IncmXR1MPk6aYvmD37It8dP6wVMzaxxzgrkIU2ACkN5UVwA+/0Sr3ZNd9dNwjpyoH1AwpL9BetnlJaWtT6K5ew==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.6.1",
                 "@aws-sdk/protocol-http": "3.6.1",
@@ -7041,14 +4758,12 @@
         "node_modules/@aws-sdk/middleware-apply-body-checksum/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.6.1.tgz",
             "integrity": "sha512-Frcqn2RQDNHy+e2Q9hv3ejT3mQWtGlfZESbXEF6toR4M0R8MmEVqIB/ohI6VKBj11lRmGwvpPsR6zz+PJ8HS7A==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.6.1",
                 "@aws-sdk/types": "3.6.1",
@@ -7062,8 +4777,7 @@
         "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/middleware-content-length": {
             "version": "3.6.1",
@@ -7120,7 +4834,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.6.1.tgz",
             "integrity": "sha512-vvMOqVYU3uvdJzg/X6NHewZUEBZhSqND1IEcdahLb6RmvDhsS39iS97VZmEFsjj/UFGoePtYjrrdEgRG9Rm1kQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-header-default": "3.6.1",
                 "@aws-sdk/protocol-http": "3.6.1",
@@ -7134,14 +4847,12 @@
         "node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/middleware-header-default": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.6.1.tgz",
             "integrity": "sha512-YD137iIctXVH8Eut0WOBalvvA+uL0jM0UXZ9N2oKrC8kPQPpqjK9lYGFKZQFsl/XlQHAjJi+gCAFrYsBntRWJQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.6.1",
                 "@aws-sdk/types": "3.6.1",
@@ -7154,8 +4865,7 @@
         "node_modules/@aws-sdk/middleware-header-default/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.6.1",
@@ -7179,7 +4889,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.6.1.tgz",
             "integrity": "sha512-nFisTc0O5D+4I+sRxiiLPasC/I4NDc3s+hgbPPt/b3uAdrujJjhwFBOSaTx8qQvz/xJPAA8pUA/bfWIyeZKi/w==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.6.1",
                 "tslib": "^1.8.0"
@@ -7191,8 +4900,7 @@
         "node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/middleware-logger": {
             "version": "3.6.1",
@@ -7712,7 +5420,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.6.1.tgz",
             "integrity": "sha512-HEA9kynNTsOSIIz8p5GEEAH03pnn+SSohwPl80sGqkmI1yl1tzjqgYZRii0e6acJTh4j9655XFzSx36hYPeB2w==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.6.1",
                 "@aws-sdk/types": "3.6.1",
@@ -7726,8 +5433,7 @@
         "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/middleware-sdk-sts": {
             "version": "3.186.0",
@@ -7882,7 +5588,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.6.1.tgz",
             "integrity": "sha512-svuH6s91uKUTORt51msiL/ZBjtYSW32c3uVoWxludd/PEf6zO5wCmUEsKoyVwa88L7rrCq+81UBv5A8S5kc3Cw==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "3.6.1",
                 "tslib": "^1.8.0"
@@ -7894,8 +5599,7 @@
         "node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/middleware-stack": {
             "version": "3.6.1",
@@ -8043,7 +5747,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.6.1.tgz",
             "integrity": "sha512-OI7UHCKBwuiO/RmHHewBKnL2NYqdilXRmpX67TJ4tTszIrWP2+vpm3lIfrx/BM8nf8nKTzgkO98uFhoJsEhmTg==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.6.1",
                 "@aws-sdk/signature-v4": "3.6.1",
@@ -8060,8 +5763,7 @@
         "node_modules/@aws-sdk/s3-request-presigner/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/service-error-classification": {
             "version": "3.6.1",
@@ -8171,7 +5873,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.6.1.tgz",
             "integrity": "sha512-NFdYeuhaSrgnBG6Pt3zHNU7QwvhHq6sKUTWZShUayLMJYYbQr6IjmYVlPST4c84b+lyDoK68y/Zga621VfIdBg==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^1.8.0"
             },
@@ -8182,8 +5883,7 @@
         "node_modules/@aws-sdk/util-arn-parser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/util-base64-browser": {
             "version": "3.6.1",
@@ -8276,7 +5976,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.6.1.tgz",
             "integrity": "sha512-jR1U8WpwXl+xZ9ThS42Jr5MXuegQ7QioHsZjQn3V5pbm8CXTkBF0B2BcULQu/2G1XtHOJb8qUZQlk/REoaORfQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-stack": "3.6.1",
                 "@aws-sdk/smithy-client": "3.6.1",
@@ -8290,8 +5989,7 @@
         "node_modules/@aws-sdk/util-create-request/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/util-defaults-mode-browser": {
             "version": "3.186.0",
@@ -8494,7 +6192,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.6.1.tgz",
             "integrity": "sha512-FvhcXcqLyJ0j0WdlmGs7PtjCCv8NaY4zBuXYO2iwAmqoy2SIZXQL63uAvmilqWj25q47ASAsUwSFLReCCfMklQ==",
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/querystring-builder": "3.6.1",
                 "@aws-sdk/types": "3.6.1",
@@ -8507,8 +6204,7 @@
         "node_modules/@aws-sdk/util-format-url/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/util-hex-encoding": {
             "version": "3.6.1",
@@ -8649,7 +6345,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.6.1.tgz",
             "integrity": "sha512-+HOCH4a0XO+I09okd0xdVP5Q5c9ZsEsDvnogiOcBQxoMivWhPUCo9pjXP3buCvVKP2oDHXQplBKSjGHvGaKFdg==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^1.8.0"
             },
@@ -8660,8 +6355,7 @@
         "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "peer": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.22.5",
@@ -14149,9 +11843,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
-            "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.5.0.tgz",
+            "integrity": "sha512-/a31lYofrMBkJb3BuPlYJTMKDj0hUmKUP6JFZQu6YVuQVoAjubiY0A52U9S0Uysd33n/djexCUSNJ+G9bf3/aA==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -14636,15 +12330,6 @@
             "version": "20.4.4",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
             "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew=="
-        },
-        "node_modules/@types/node-fetch": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-            "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
-            "dependencies": {
-                "@types/node": "*",
-                "form-data": "^3.0.0"
-            }
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
@@ -15414,12 +13099,12 @@
             }
         },
         "node_modules/amazon-cognito-identity-js": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.1.tgz",
-            "integrity": "sha512-PxBdufgS8uZShrcIFAsRjmqNXsh/4fXOWUGQOUhKLHWWK1pcp/y+VeFF48avXIWefM8XwsT3JlN6m9J2eHt4LA==",
+            "version": "5.2.14",
+            "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.14.tgz",
+            "integrity": "sha512-9LMgLZfbypbbGTpARQ+QqglE09b1MWti11NXhcD/wPom0uhU/L90dfmUOpTwknz//eE6/dGYf004mJucWzrfxQ==",
             "dependencies": {
-                "@aws-crypto/sha256-js": "1.2.2",
                 "buffer": "4.9.2",
+                "crypto-js": "^4.1.1",
                 "fast-base64-decode": "^1.0.0",
                 "isomorphic-unfetch": "^3.0.0",
                 "js-cookie": "^2.2.1"
@@ -15779,23 +13464,23 @@
             }
         },
         "node_modules/aws-amplify": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-5.3.5.tgz",
-            "integrity": "sha512-3xUJqHdQMoyOYDlq6K1z1kXQnlsOx0cN/R4WpfcbGBeiixsxEpxTk+OGQijOQwE1CIOJ4OXPCNz5m2yRofTTyw==",
+            "version": "4.3.46",
+            "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.46.tgz",
+            "integrity": "sha512-LygkBq+mrV+hFf3DCrVcyYNxFsiYwL0HLN89X1Eg+s3f7df6T2xpjh4JuaDJFbmodEdAlZNfdtRGLMk6ApnPcA==",
             "dependencies": {
-                "@aws-amplify/analytics": "6.4.1",
-                "@aws-amplify/api": "5.3.5",
-                "@aws-amplify/auth": "5.5.5",
-                "@aws-amplify/cache": "5.1.5",
-                "@aws-amplify/core": "5.7.0",
-                "@aws-amplify/datastore": "4.6.5",
-                "@aws-amplify/geo": "2.2.0",
-                "@aws-amplify/interactions": "5.2.5",
-                "@aws-amplify/notifications": "1.5.0",
-                "@aws-amplify/predictions": "5.4.5",
-                "@aws-amplify/pubsub": "5.4.1",
-                "@aws-amplify/storage": "5.8.0",
-                "tslib": "^2.0.0"
+                "@aws-amplify/analytics": "5.2.31",
+                "@aws-amplify/api": "4.0.64",
+                "@aws-amplify/auth": "4.6.17",
+                "@aws-amplify/cache": "4.0.66",
+                "@aws-amplify/core": "4.7.15",
+                "@aws-amplify/datastore": "3.14.7",
+                "@aws-amplify/geo": "1.3.27",
+                "@aws-amplify/interactions": "4.1.12",
+                "@aws-amplify/predictions": "4.0.64",
+                "@aws-amplify/pubsub": "4.5.14",
+                "@aws-amplify/storage": "4.5.17",
+                "@aws-amplify/ui": "2.0.7",
+                "@aws-amplify/xr": "3.0.64"
             }
         },
         "node_modules/axe-core": {
@@ -17158,10 +14843,9 @@
             }
         },
         "node_modules/crypto-js": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-            "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
-            "peer": true
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
         },
         "node_modules/crypto-random-string": {
             "version": "2.0.0",
@@ -19419,6 +17103,7 @@
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "strnum": "^1.0.5"
             },
@@ -26404,8 +24089,7 @@
         "node_modules/paho-mqtt": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/paho-mqtt/-/paho-mqtt-1.1.0.tgz",
-            "integrity": "sha512-KPbL9KAB0ASvhSDbOrZBaccXS+/s7/LIofbPyERww8hM5Ko71GUJQ6Nmg0BWqj8phAIT8zdf/Sd/RftHU9i2HA==",
-            "peer": true
+            "integrity": "sha512-KPbL9KAB0ASvhSDbOrZBaccXS+/s7/LIofbPyERww8hM5Ko71GUJQ6Nmg0BWqj8phAIT8zdf/Sd/RftHU9i2HA=="
         },
         "node_modules/pako": {
             "version": "2.0.4",
@@ -31646,50 +29330,6 @@
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/whatwg-url-without-unicode": {
-            "version": "8.0.0-3",
-            "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
-            "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
-            "dependencies": {
-                "buffer": "^5.4.3",
-                "punycode": "^2.1.1",
-                "webidl-conversions": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/whatwg-url-without-unicode/node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
-        "node_modules/whatwg-url-without-unicode/node_modules/webidl-conversions": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-            "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/whatwg-url/node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@material-ui/icons": "^4.11.3",
         "@mui/icons-material": "^5.14.1",
         "@mui/material": "^5.14.2",
-        "aws-amplify": "^5.3.5",
+        "aws-amplify": "^4.3.46",
         "bootstrap-css-only": "4.4.1",
         "env-cmd": "^10.1.0",
         "mdbreact": "^5.2.0",


### PR DESCRIPTION
aws-amplify was bumped to 5.3.5 in https://github.com/HicResearch/treehoose-egress-app-frontend/pull/22 and worked fine when tested on treehoose with federated login, but it doesn't work on HIC-TRE staging with non-federated login.

----

Declaration : _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
